### PR TITLE
feat: add support for ErrorBoundary exports

### DIFF
--- a/example/src/routes/__panel/posts/$slug.tsx
+++ b/example/src/routes/__panel/posts/$slug.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   LoaderFunction,
   NavLink,
   useLoaderData,

--- a/example/src/routes/__panel/posts/index.tsx
+++ b/example/src/routes/__panel/posts/index.tsx
@@ -1,9 +1,20 @@
-import { LoaderFunction, NavLink, useLoaderData } from 'react-router-dom'
+import {
+  LoaderFunction,
+  NavLink,
+  useLoaderData,
+  useRouteError,
+} from 'react-router-dom'
 import { Post } from '@ngneat/falso'
 import { slugify } from '../../../utils'
 
 export const loader: LoaderFunction = async () => {
-  return fetch('/api/posts').then((response) => response.json())
+  const response = await fetch('/api/posts')
+
+  if (response.status === 400) {
+    throw new Response('Oops! Something went wrong.', { status: 400 })
+  }
+
+  return await response.json()
 }
 
 export default function () {
@@ -26,4 +37,9 @@ export default function () {
       </div>
     </div>
   )
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError() as { data: string } | undefined
+  return <div className="text-2xl text-red-600">{error?.data}</div>
 }

--- a/example/tests/posts.e2e.ts
+++ b/example/tests/posts.e2e.ts
@@ -1,7 +1,7 @@
 import { randPost } from '@ngneat/falso'
 import { slugify } from '../src/utils'
 
-it('should fetch and render posts', () => {
+it('should fetch and render all posts', () => {
   const posts = randPost({ length: 10 })
 
   cy.intercept('GET', '/api/posts', (request) => {
@@ -15,7 +15,17 @@ it('should fetch and render posts', () => {
   })
 })
 
-it('should fetch and render posts', () => {
+it('should `ErrorBoundary` when error occurs', () => {
+  cy.intercept('GET', '/api/posts', (request) => {
+    request.reply({ statusCode: 400 })
+  })
+
+  cy.visit('/posts')
+
+  cy.findByText('Oops! Something went wrong.').should('exist')
+})
+
+it('should fetch and render a post by its slug', () => {
   const post = randPost()
 
   cy.intercept('GET', `/api/posts/${slugify(post.title)}`, (request) => {

--- a/src/__snapshots__/generateRoutesModule.test.ts.snap
+++ b/src/__snapshots__/generateRoutesModule.test.ts.snap
@@ -6,6 +6,7 @@ import { loader as example_src_routes___panel_posts_$slug_LOADER } from '/exampl
 import { ErrorElement as EXAMPLE_SRC_ROUTES___PANEL_POSTS_$SLUG_ERROR_ELEMENT } from '/example/src/routes/__panel/posts/$slug.tsx';
 import { action as example_src_routes___panel_posts_create_ACTION } from '/example/src/routes/__panel/posts/create.tsx';
 import { loader as example_src_routes___panel_posts_index_LOADER } from '/example/src/routes/__panel/posts/index.tsx';
+import { ErrorBoundary as EXAMPLE_SRC_ROUTES___PANEL_POSTS_INDEX_ERROR_ELEMENT } from '/example/src/routes/__panel/posts/index.tsx';
 
 export const routes = [{
   \\"path\\": \\"/\\",
@@ -42,6 +43,7 @@ export const routes = [{
             {
               \\"index\\": true,
               \\"loader\\": example_src_routes___panel_posts_index_LOADER,
+              \\"errorElement\\": React.createElement(EXAMPLE_SRC_ROUTES___PANEL_POSTS_INDEX_ERROR_ELEMENT),
               \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/posts/index.tsx\\")))
             }
           ]

--- a/src/generateRoutesModule.ts
+++ b/src/generateRoutesModule.ts
@@ -4,6 +4,7 @@ import type { RouteNode } from './buildRouteTree'
 import {
   createImportName,
   hasAction,
+  hasErrorBoundary,
   hasErrorElement,
   hasLoader,
   normalizeFilenameToRoute,
@@ -99,6 +100,16 @@ function resolveErrorElement(filePath: string, code: string) {
 
     imports.push(
       `import { ErrorElement as ${importName} } from '/${filePath}';`,
+    )
+
+    return `::React.createElement(${importName})::`
+  }
+
+  if (hasErrorBoundary(code)) {
+    const importName = createImportName(filePath, 'ERROR_ELEMENT').toUpperCase()
+
+    imports.push(
+      `import { ErrorBoundary as ${importName} } from '/${filePath}';`,
     )
 
     return `::React.createElement(${importName})::`

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   createImportName,
   hasAction,
+  hasErrorBoundary,
   hasErrorElement,
   hasLoader,
   isCatchAllRoute,
@@ -78,4 +79,12 @@ it('hasErrorElement', () => {
   expect(hasErrorElement(`export const ErrorElement = () => {}`)).toEqual(true)
   expect(hasErrorElement(`const ErrorElement = () => {}`)).toEqual(true)
   expect(hasErrorElement(`export function ErrorElement () {}`)).toEqual(true)
+})
+
+it('hasErrorBoundary', () => {
+  expect(hasErrorBoundary(`export const ErrorBoundary = () => {}`)).toEqual(
+    true,
+  )
+  expect(hasErrorBoundary(`const ErrorBoundary = () => {}`)).toEqual(true)
+  expect(hasErrorBoundary(`export function ErrorBoundary () {}`)).toEqual(true)
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,8 @@ const ROUTE_LOADER_REGEX = /(export\s)?(async\s)?(const|function)\sloader/
 const ROUTE_ACTION_REGEX = /(export\s)?(async\s)?(const|function)\saction/
 const ROUTE_ERROR_ELEMENT_REGEX =
   /(export\s)?(async\s)?(const|function)\sErrorElement/
+const ROUTE_ERROR_BOUNDARY_REGEX =
+  /(export\s)?(async\s)?(const|function)\sErrorBoundary/
 
 export function isDirectory(filePath: string) {
   return fs.statSync(filePath).isDirectory()
@@ -60,4 +62,8 @@ export function hasAction(code: string) {
 
 export function hasErrorElement(code: string) {
   return ROUTE_ERROR_ELEMENT_REGEX.test(code)
+}
+
+export function hasErrorBoundary(code: string) {
+  return ROUTE_ERROR_BOUNDARY_REGEX.test(code)
 }


### PR DESCRIPTION
With this PR, It's possible to export an `ErrorBoundary` component as the route `errorElement`.