### PR TITLE
feat: add support for route `handle`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 .idea
+cache

--- a/example/src/components/Breadcrumbs.tsx
+++ b/example/src/components/Breadcrumbs.tsx
@@ -1,0 +1,22 @@
+import { useMatches } from 'react-router-dom'
+
+export function Breadcrumbs() {
+  const matches = useMatches()
+
+  const crumbs: Array<string> = matches
+    .filter((match) => Boolean((match.handle as any)?.crumb))
+    .map((match) => (match.handle as any)?.crumb(match.params))
+
+  return (
+    <nav>
+      <ol className="flex space-x-2 text-gray-600 text-sm">
+        {crumbs.map((crumb, index) => (
+          <>
+            <li key={index}>{crumb}</li>
+            {index < crumbs.length - 1 && <li className="text-gray-300">/</li>}
+          </>
+        ))}
+      </ol>
+    </nav>
+  )
+}

--- a/example/src/routes/__panel/users.tsx
+++ b/example/src/routes/__panel/users.tsx
@@ -1,0 +1,13 @@
+import { Link, Outlet } from 'react-router-dom'
+
+export default function UsersLayout() {
+  return <Outlet />
+}
+
+export const handle = {
+  crumb: () => (
+    <Link to="/users" className="text-blue-500">
+      Users
+    </Link>
+  ),
+}

--- a/example/src/routes/__panel/users/$user.tsx
+++ b/example/src/routes/__panel/users/$user.tsx
@@ -1,10 +1,14 @@
 import { NavLink, Outlet, useParams } from 'react-router-dom'
+import { Breadcrumbs } from '../../../components/Breadcrumbs'
 
 export default function () {
   const { user } = useParams()
+
   return (
     <div>
-      <h1 className="text-2xl">User: {user}</h1>
+      <Breadcrumbs />
+
+      <h1 className="text-2xl mt-8">User: {user}</h1>
 
       <div className="mt-8">
         <div className="flex border-b border-gray-200 text-gray-500">
@@ -40,4 +44,10 @@ export default function () {
       </div>
     </div>
   )
+}
+
+export const handle = {
+  crumb: ({ user }: { user: string }) => (
+    <span className="capitalize">{user}</span>
+  ),
 }

--- a/example/src/routes/__panel/users/$user/index.tsx
+++ b/example/src/routes/__panel/users/$user/index.tsx
@@ -1,3 +1,7 @@
 export default function () {
   return <h2 className="text-2xl">Overview</h2>
 }
+
+export const handle = {
+  crumb: () => 'Overview',
+}

--- a/example/src/routes/__panel/users/$user/profile.tsx
+++ b/example/src/routes/__panel/users/$user/profile.tsx
@@ -1,3 +1,7 @@
 export default function () {
   return <h2 className="text-2xl">Profile</h2>
 }
+
+export const handle = {
+  crumb: () => 'Profile',
+}

--- a/example/src/routes/__panel/users/$user/settings.tsx
+++ b/example/src/routes/__panel/users/$user/settings.tsx
@@ -1,3 +1,7 @@
 export default function () {
   return <h2 className="text-2xl">Settings</h2>
 }
+
+export const handle = {
+  crumb: () => 'Settings',
+}

--- a/src/__snapshots__/buildRouteTree.test.ts.snap
+++ b/src/__snapshots__/buildRouteTree.test.ts.snap
@@ -96,7 +96,7 @@ RouteNode {
             },
           ],
           "isDirectory": true,
-          "layoutPath": undefined,
+          "layoutPath": "example/src/routes/__panel/users.tsx",
           "name": "users",
           "path": "example/src/routes/__panel/users",
         },

--- a/src/__snapshots__/generateRoutesModule.test.ts.snap
+++ b/src/__snapshots__/generateRoutesModule.test.ts.snap
@@ -7,6 +7,11 @@ import { ErrorElement as EXAMPLE_SRC_ROUTES___PANEL_POSTS_$SLUG_ERROR_ELEMENT } 
 import { action as example_src_routes___panel_posts_create_ACTION } from '/example/src/routes/__panel/posts/create.tsx';
 import { loader as example_src_routes___panel_posts_index_LOADER } from '/example/src/routes/__panel/posts/index.tsx';
 import { ErrorBoundary as EXAMPLE_SRC_ROUTES___PANEL_POSTS_INDEX_ERROR_ELEMENT } from '/example/src/routes/__panel/posts/index.tsx';
+import { handle as example_src_routes___panel_users_HANDLE } from '/example/src/routes/__panel/users';
+import { handle as example_src_routes___panel_users_$user_HANDLE } from '/example/src/routes/__panel/users/$user';
+import { handle as example_src_routes___panel_users_$user_index_HANDLE } from '/example/src/routes/__panel/users/$user/index.tsx';
+import { handle as example_src_routes___panel_users_$user_profile_HANDLE } from '/example/src/routes/__panel/users/$user/profile.tsx';
+import { handle as example_src_routes___panel_users_$user_settings_HANDLE } from '/example/src/routes/__panel/users/$user/settings.tsx';
 
 export const routes = [{
   \\"path\\": \\"/\\",
@@ -49,6 +54,7 @@ export const routes = [{
           ]
         },
         {
+          \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users.tsx\\"))),
           \\"path\\": \\"users\\",
           \\"children\\": [
             {
@@ -57,23 +63,28 @@ export const routes = [{
               \\"children\\": [
                 {
                   \\"index\\": true,
+                  \\"handle\\": example_src_routes___panel_users_$user_index_HANDLE,
                   \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user/index.tsx\\")))
                 },
                 {
                   \\"path\\": \\"profile\\",
+                  \\"handle\\": example_src_routes___panel_users_$user_profile_HANDLE,
                   \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user/profile.tsx\\")))
                 },
                 {
                   \\"path\\": \\"settings\\",
+                  \\"handle\\": example_src_routes___panel_users_$user_settings_HANDLE,
                   \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user/settings.tsx\\")))
                 }
-              ]
+              ],
+              \\"handle\\": example_src_routes___panel_users_$user_HANDLE
             },
             {
               \\"index\\": true,
               \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/index.tsx\\")))
             }
-          ]
+          ],
+          \\"handle\\": example_src_routes___panel_users_HANDLE
         }
       ]
     },

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -3,6 +3,7 @@ import {
   hasAction,
   hasErrorBoundary,
   hasErrorElement,
+  hasHandle,
   hasLoader,
   isCatchAllRoute,
   isDynamicRoute,
@@ -87,4 +88,20 @@ it('hasErrorBoundary', () => {
   )
   expect(hasErrorBoundary(`const ErrorBoundary = () => {}`)).toEqual(true)
   expect(hasErrorBoundary(`export function ErrorBoundary () {}`)).toEqual(true)
+})
+
+it('hasHandle', () => {
+  expect(hasHandle(`export const handle = {}`)).toEqual(true)
+  expect(hasHandle(`const handle = {}`)).toEqual(true)
+  expect(hasHandle(`export let handle = {}`)).toEqual(true)
+  expect(hasHandle(`let handle = {}`)).toEqual(true)
+  expect(hasHandle(`export var handle = {}`)).toEqual(true)
+  expect(hasHandle(`var handle = {}`)).toEqual(true)
+
+  expect(hasHandle(`export const handleForm =`)).toEqual(false)
+  expect(hasHandle(`const handleForm =`)).toEqual(false)
+  expect(hasHandle(`export let handleForm =`)).toEqual(false)
+  expect(hasHandle(`let handleForm =`)).toEqual(false)
+  expect(hasHandle(`export var handleForm =`)).toEqual(false)
+  expect(hasHandle(`var handleForm =`)).toEqual(false)
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ const ROUTE_ERROR_ELEMENT_REGEX =
   /(export\s)?(async\s)?(const|function)\sErrorElement/
 const ROUTE_ERROR_BOUNDARY_REGEX =
   /(export\s)?(async\s)?(const|function)\sErrorBoundary/
+const ROUTE_HANDLE_REGEX = /(export\s)?(const|var|let)\shandle\s/
 
 export function isDirectory(filePath: string) {
   return fs.statSync(filePath).isDirectory()
@@ -66,4 +67,8 @@ export function hasErrorElement(code: string) {
 
 export function hasErrorBoundary(code: string) {
   return ROUTE_ERROR_BOUNDARY_REGEX.test(code)
+}
+
+export function hasHandle(code: string) {
+  return ROUTE_HANDLE_REGEX.test(code)
 }


### PR DESCRIPTION
This PR adds support for [route `handle` objects](https://reactrouter.com/en/main/route/route#handle).