### PR TITLE
feat: use route.lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,30 @@
 # Changelog
 
-## [1.2.0](https://github.com/mammadataei/vite-plugin-remix-router/compare/v1.1.0...v1.2.0) (2023-02-20)
+## 2.0.0
 
+- Use [route.lazy](https://reactrouter.com/en/main/route/lazy)
+
+## [1.2.0](https://github.com/mammadataei/vite-plugin-remix-router/compare/v1.1.0...v1.2.0) (2023-02-20)
 
 ### Features
 
-* add support for route `handle` ([#37](https://github.com/mammadataei/vite-plugin-remix-router/issues/37)) ([85a7b2a](https://github.com/mammadataei/vite-plugin-remix-router/commit/85a7b2a654fa5a43f46d589e18d7893d2b6da8bc))
+- add support for route `handle`
+  ([#37](https://github.com/mammadataei/vite-plugin-remix-router/issues/37))
+  ([85a7b2a](https://github.com/mammadataei/vite-plugin-remix-router/commit/85a7b2a654fa5a43f46d589e18d7893d2b6da8bc))
 
 ## [1.1.0](https://github.com/mammadataei/vite-plugin-remix-router/compare/v1.0.0...v1.1.0) (2022-12-10)
 
-
 ### Features
 
-* add route loader support ([#1](https://github.com/mammadataei/vite-plugin-remix-router/issues/1)) ([eb13dc2](https://github.com/mammadataei/vite-plugin-remix-router/commit/eb13dc2b12432784eb9a2cb86f5301f4c72e54ca))
-* add support for ErrorBoundary exports ([#4](https://github.com/mammadataei/vite-plugin-remix-router/issues/4)) ([f9cbcad](https://github.com/mammadataei/vite-plugin-remix-router/commit/f9cbcad4cd76e8515126f48d622d3ada99aad892))
-* add support for route action ([#2](https://github.com/mammadataei/vite-plugin-remix-router/issues/2)) ([69f050a](https://github.com/mammadataei/vite-plugin-remix-router/commit/69f050a38a5217ea83c100927778248d4b04656b))
-* add support for route ErrorElement ([#3](https://github.com/mammadataei/vite-plugin-remix-router/issues/3)) ([034cb78](https://github.com/mammadataei/vite-plugin-remix-router/commit/034cb7895c34758952e3cab8f518bbece0a3003f))
+- add route loader support
+  ([#1](https://github.com/mammadataei/vite-plugin-remix-router/issues/1))
+  ([eb13dc2](https://github.com/mammadataei/vite-plugin-remix-router/commit/eb13dc2b12432784eb9a2cb86f5301f4c72e54ca))
+- add support for ErrorBoundary exports
+  ([#4](https://github.com/mammadataei/vite-plugin-remix-router/issues/4))
+  ([f9cbcad](https://github.com/mammadataei/vite-plugin-remix-router/commit/f9cbcad4cd76e8515126f48d622d3ada99aad892))
+- add support for route action
+  ([#2](https://github.com/mammadataei/vite-plugin-remix-router/issues/2))
+  ([69f050a](https://github.com/mammadataei/vite-plugin-remix-router/commit/69f050a38a5217ea83c100927778248d4b04656b))
+- add support for route ErrorElement
+  ([#3](https://github.com/mammadataei/vite-plugin-remix-router/issues/3))
+  ([034cb78](https://github.com/mammadataei/vite-plugin-remix-router/commit/034cb7895c34758952e3cab8f518bbece0a3003f))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2.0.0
-
-- Use [route.lazy](https://reactrouter.com/en/main/route/lazy)
-
 ## [1.2.0](https://github.com/mammadataei/vite-plugin-remix-router/compare/v1.1.0...v1.2.0) (2023-02-20)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in your Vite-powered React project.
 
 - Remix-style file-system routing
 - Nested and pathless layout routes
-- Route `actions`, `loaders`, and `errorElement`
+- Route `actions`, `loaders`
 - Type-safe and full typescript support
 - Flexible and customizable
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in your Vite-powered React project.
 
 - Remix-style file-system routing
 - Nested and pathless layout routes
-- Route `actions`, `loaders`
+- Route `actions`, `loaders`, and `errorElement`
 - Type-safe and full typescript support
 - Flexible and customizable
 

--- a/docs/guides/defining-routes.md
+++ b/docs/guides/defining-routes.md
@@ -30,7 +30,7 @@ Now let's define the route component:
 ```tsx
 // routes/about.tsx
 
-export default function About() {
+export function Component() {
   return <h1>About</h1>
 }
 ```
@@ -45,7 +45,7 @@ with the name of the route. Let's create a new route for `/users/profile`:
 ```tsx
 // routes/users/profile.tsx
 
-export default function Profile() {
+export function Component() {
   return <h1>Profile</h1>
 }
 ```
@@ -64,7 +64,7 @@ directory:
 // routes/users/$id.tsx
 import { useParams } from 'react-router-dom'
 
-export default function User() {
+export function Component() {
   const { id } = useParams()
 
   return <h1>User {id}</h1>
@@ -81,7 +81,7 @@ index route for the `routes/users` directory:
 ```tsx
 // routes/users/index.tsx
 
-export default function Users() {
+export function Component() {
   return <h1>Users</h1>
 }
 ```
@@ -99,7 +99,7 @@ create a file called `users.tsx` next to the `users` directory:
 // routes/users.tsx
 import { Outlet } from 'react-router-dom'
 
-export default function UsersLayout() {
+export function Component() {
   return (
     <div>
       <h1>Users Layout</h1>
@@ -122,19 +122,19 @@ layout file with a name that starts with a two `_`.
 
 ```tsx
 // routes/__auth/login.tsx
-export default function Login() {
+export function Component() {
   return <h1>Login</h1>
 }
 
 // routes/__auth/register.tsx
-export default function Register() {
+export function Component() {
   return <h1>Register</h1>
 }
 
 // routes/__auth.tsx
 import { Outlet } from 'react-router-dom'
 
-export default function AuthLayout() {
+export function Component() {
   return (
     <div>
       <h1>Auth Layout</h1>
@@ -155,7 +155,7 @@ named `$.tsx`.
 ```tsx
 // routes/$.tsx
 
-export default function NotFound() {
+export function Component() {
   return <h1>Not Found</h1>
 }
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -49,7 +49,7 @@ mkdir src/routes && touch src/routes/hello.tsx
 ```tsx
 // src/routes/hello.tsx
 
-export default function Hello() {
+export function Component() {
   return (
     <div>
       <h1>Hello World!</h1>

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -8,6 +8,7 @@ in your Vite-powered React project.
 
 - Remix-style file-system routing
 - Nested and pathless layout routes
-- Route `actions`, `loaders`, and `errorElement`
+- Route `actions`, `loaders`, `ErrorBoundary`, `handle` - anything supported by
+  [route.lazy](https://reactrouter.com/en/main/route/lazy)!
 - Type-safe and full typescript support
 - Flexible and customizable

--- a/docs/guides/using-data-apis.md
+++ b/docs/guides/using-data-apis.md
@@ -24,7 +24,7 @@ export const loader: LoaderFunction = async () => {
   return fetch('/api/posts').then((res) => res.json())
 }
 
-export default function Posts() {
+export function Component() {
   let posts = useLoaderData()
 
   return (
@@ -62,7 +62,7 @@ export const action: ActionFunction = async ({ request }) => {
   }).then((response) => response.json())
 }
 
-export default function CreatePost() {
+export function Component() {
   // this will be the response from the action
   const data = useActionData()
 
@@ -77,32 +77,6 @@ export default function CreatePost() {
       <button type="submit">Create new post</button>
     </Form>
   )
-}
-```
-
-## Error Elements
-
-Error Elements allow you to render a custom error element when an error occurs
-while loading or submitting data. To learn more about route `errorElements`,
-check out the
-[Route Error Elements](https://reactrouter.com/en/main/route/error-element)
-guide.
-
-To define a route `errorElement`, you can export an `ErrorElement` or
-`ErrorBoundary` component from your route's module.
-
-```tsx
-export function ErrorElement() {
-  // the error data
-  const error = useRouteError()
-  return <div>Oops! Something went wrong.</div>
-}
-
-// or
-
-export function ErrorBoundary() {
-  const error = useRouteError()
-  return <div>Oops! Something went wrong.</div>
 }
 ```
 

--- a/docs/guides/using-data-apis.md
+++ b/docs/guides/using-data-apis.md
@@ -80,6 +80,24 @@ export function Component() {
 }
 ```
 
+## Error Elements
+
+Error Elements allow you to render a custom error element when an error occurs
+while loading or submitting data. To learn more about route `errorElements`,
+check out the
+[Route Error Elements](https://reactrouter.com/en/main/route/error-element)
+guide.
+
+To define a route `errorElement`, you can export an `ErrorBoundary` component
+from your route's module.
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError()
+  return <div>Oops! Something went wrong.</div>
+}
+```
+
 ## Handle
 
 A route handle is useful for adding any application-specific data to routes. To

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ features:
   - title: Nested and pathless layout routes
     details: Custom layouts for each directory even without a path.
 
-  - title: Route `actions`, `loaders`
+  - title: Route `actions`, `loaders`, and `errorElement`
     details:
       Use the react-router^6.4.0 data APIs to preload data and handle errors.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ features:
   - title: Nested and pathless layout routes
     details: Custom layouts for each directory even without a path.
 
-  - title: Route `actions`, `loaders`, and `errorElement`
+  - title: Route `actions`, `loaders`
     details:
       Use the react-router^6.4.0 data APIs to preload data and handle errors.
 

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.1"
+    "react-router-dom": "^6.9.0"
   },
   "devDependencies": {
     "@ngneat/falso": "^6.1.0",

--- a/example/src/routes/$.tsx
+++ b/example/src/routes/$.tsx
@@ -1,4 +1,4 @@
-export default function () {
+export function Component() {
   return (
     <div className="w-full h-full flex justify-center items-center">
       <h1 className="text-4xl text-gray-800">404 - Not Found</h1>

--- a/example/src/routes/__auth/login.tsx
+++ b/example/src/routes/__auth/login.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-export default function () {
+export function Component() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const redirect = useNavigate()

--- a/example/src/routes/__panel.tsx
+++ b/example/src/routes/__panel.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom'
 import { Sidebar } from '../components/Sidebar'
 
-export default function PanelLayout() {
+export function Component() {
   return (
     <div className="w-full h-full flex">
       <div className="w-1/5">

--- a/example/src/routes/__panel/posts/$slug.tsx
+++ b/example/src/routes/__panel/posts/$slug.tsx
@@ -16,7 +16,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   return await response.json()
 }
 
-export default function () {
+export function Component() {
   const { post } = useLoaderData() as { post: Post }
 
   return (

--- a/example/src/routes/__panel/posts/$slug.tsx
+++ b/example/src/routes/__panel/posts/$slug.tsx
@@ -30,7 +30,7 @@ export function Component() {
   )
 }
 
-export function ErrorElement() {
+export function ErrorBoundary() {
   const error = useRouteError() as { data: string } | undefined
   return <div className="text-2xl text-red-600">{error?.data}</div>
 }

--- a/example/src/routes/__panel/posts/create.tsx
+++ b/example/src/routes/__panel/posts/create.tsx
@@ -12,7 +12,7 @@ export const action: ActionFunction = async ({ request }) => {
   }).then((response) => response.json())
 }
 
-export default function CreatePost() {
+export function Component() {
   const data = useActionData() as { message: string }
 
   return (

--- a/example/src/routes/__panel/posts/index.tsx
+++ b/example/src/routes/__panel/posts/index.tsx
@@ -17,7 +17,7 @@ export const loader: LoaderFunction = async () => {
   return await response.json()
 }
 
-export default function () {
+export function Component() {
   const { posts } = useLoaderData() as { posts: Post[] }
 
   return (

--- a/example/src/routes/__panel/users.tsx
+++ b/example/src/routes/__panel/users.tsx
@@ -1,6 +1,6 @@
 import { Link, Outlet } from 'react-router-dom'
 
-export default function UsersLayout() {
+export function Component() {
   return <Outlet />
 }
 

--- a/example/src/routes/__panel/users/$user.tsx
+++ b/example/src/routes/__panel/users/$user.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Outlet, useParams } from 'react-router-dom'
 import { Breadcrumbs } from '../../../components/Breadcrumbs'
 
-export default function () {
+export function Component() {
   const { user } = useParams()
 
   return (

--- a/example/src/routes/__panel/users/$user/index.tsx
+++ b/example/src/routes/__panel/users/$user/index.tsx
@@ -1,4 +1,4 @@
-export default function () {
+export function Component() {
   return <h2 className="text-2xl">Overview</h2>
 }
 

--- a/example/src/routes/__panel/users/$user/profile.tsx
+++ b/example/src/routes/__panel/users/$user/profile.tsx
@@ -1,4 +1,4 @@
-export default function () {
+export function Component() {
   return <h2 className="text-2xl">Profile</h2>
 }
 

--- a/example/src/routes/__panel/users/$user/settings.tsx
+++ b/example/src/routes/__panel/users/$user/settings.tsx
@@ -1,4 +1,4 @@
-export default function () {
+export function Component() {
   return <h2 className="text-2xl">Settings</h2>
 }
 

--- a/example/src/routes/__panel/users/index.tsx
+++ b/example/src/routes/__panel/users/index.tsx
@@ -11,7 +11,7 @@ const users = [
   },
 ]
 
-export default function () {
+export function Component() {
   return (
     <div className=" w-full h-full">
       <h1 className="text-2xl">Users</h1>

--- a/example/src/routes/about.tsx
+++ b/example/src/routes/about.tsx
@@ -1,4 +1,4 @@
-export default function () {
+export function Component() {
   return (
     <div className="w-full h-full flex flex-col justify-center items-center">
       <h1 className="text-2xl">About</h1>

--- a/example/src/routes/index.tsx
+++ b/example/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { Navigate } from 'react-router-dom'
 
-export default function () {
+export function Component() {
   return <Navigate to="/login" />
 }

--- a/example/tests/posts.e2e.ts
+++ b/example/tests/posts.e2e.ts
@@ -38,7 +38,7 @@ it('should fetch and render a post by its slug', () => {
   cy.findByText(post.body).should('exist')
 })
 
-it('should render `ErrorElement` when error occurs', () => {
+it('should render `ErrorBoundary` when error occurs', () => {
   cy.intercept('GET', `/api/posts/hello-world`, (request) => {
     request.reply({
       statusCode: 404,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "*.{js,jsx,ts,tsx,md,html,css}": "prettier --write"
   },
   "peerDependencies": {
-    "react-router-dom": "^6.4.0",
+    "react-router-dom": "^6.9.0",
     "vite": ">=2"
   },
   "devDependencies": {
@@ -72,7 +72,7 @@
     "prettier": "2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.2",
+    "react-router-dom": "^6.9.0",
     "typescript": "^4.8.4",
     "unbuild": "^1.0.0",
     "vite": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       prettier: 2.8.4
       react: ^18.2.0
       react-dom: ^18.2.0
-      react-router-dom: ^6.4.2
+      react-router-dom: ^6.9.0
       typescript: ^4.8.4
       unbuild: ^1.0.0
       vite: ^4.0.0
@@ -38,7 +38,7 @@ importers:
       prettier: 2.8.4
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router-dom: 6.4.2_biqbaboplfbrettd7655fr4n2y
+      react-router-dom: 6.9.0_biqbaboplfbrettd7655fr4n2y
       typescript: 4.8.4
       unbuild: 1.0.1
       vite: 4.0.1_@types+node@18.8.5
@@ -1257,8 +1257,8 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@remix-run/router/1.0.2:
-    resolution: {integrity: sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ==}
+  /@remix-run/router/1.4.0:
+    resolution: {integrity: sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==}
     engines: {node: '>=14'}
     dev: true
 
@@ -4737,17 +4737,17 @@ packages:
       react-router: 6.4.1_react@18.2.0
     dev: false
 
-  /react-router-dom/6.4.2_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==}
+  /react-router-dom/6.9.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.0.2
+      '@remix-run/router': 1.4.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router: 6.4.2_react@18.2.0
+      react-router: 6.9.0_react@18.2.0
     dev: true
 
   /react-router/6.4.1_react@18.2.0:
@@ -4760,13 +4760,13 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-router/6.4.2_react@18.2.0:
-    resolution: {integrity: sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==}
+  /react-router/6.9.0_react@18.2.0:
+    resolution: {integrity: sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.0.2
+      '@remix-run/router': 1.4.0
       react: 18.2.0
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
       cypress-vite: ^1.1.1
       react: ^18.2.0
       react-dom: ^18.2.0
-      react-router-dom: ^6.4.1
+      react-router-dom: ^6.9.0
       start-server-and-test: ^1.14.0
       typescript: ^4.8.3
       unocss: ^0.49.0
@@ -67,7 +67,7 @@ importers:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-router-dom: 6.4.1_biqbaboplfbrettd7655fr4n2y
+      react-router-dom: 6.9.0_biqbaboplfbrettd7655fr4n2y
     devDependencies:
       '@ngneat/falso': 6.1.0
       '@testing-library/cypress': 9.0.0_cypress@12.2.0
@@ -1252,15 +1252,9 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@remix-run/router/1.0.1:
-    resolution: {integrity: sha512-eBV5rvW4dRFOU1eajN7FmYxjAIVz/mRHgUE9En9mBn6m3mulK3WTR5C3iQhL9MZ14rWAq+xOlEaCkDiW0/heOg==}
-    engines: {node: '>=14'}
-    dev: false
-
   /@remix-run/router/1.4.0:
     resolution: {integrity: sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==}
     engines: {node: '>=14'}
-    dev: true
 
   /@rollup/plugin-alias/4.0.2_rollup@3.5.0:
     resolution: {integrity: sha512-1hv7dBOZZwo3SEupxn4UA2N0EDThqSSS+wI1St1TNTBtOZvUchyIClyHcnDcjjrReTPZ47Faedrhblv4n+T5UQ==}
@@ -4724,19 +4718,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom/6.4.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-MY7NJCrGNVJtGp8ODMOBHu20UaIkmwD2V3YsAOUQoCXFk7Ppdwf55RdcGyrSj+ycSL9Uiwrb3gTLYSnzcRoXww==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.0.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-router: 6.4.1_react@18.2.0
-    dev: false
-
   /react-router-dom/6.9.0_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==}
     engines: {node: '>=14'}
@@ -4748,17 +4729,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.9.0_react@18.2.0
-    dev: true
-
-  /react-router/6.4.1_react@18.2.0:
-    resolution: {integrity: sha512-OJASKp5AykDWFewgWUim1vlLr7yfD4vO/h+bSgcP/ix8Md+LMHuAjovA74MQfsfhQJGGN1nHRhwS5qQQbbBt3A==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.0.1
-      react: 18.2.0
-    dev: false
 
   /react-router/6.9.0_react@18.2.0:
     resolution: {integrity: sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==}
@@ -4768,7 +4738,6 @@ packages:
     dependencies:
       '@remix-run/router': 1.4.0
       react: 18.2.0
-    dev: true
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/src/__snapshots__/generateRoutesModule.test.ts.snap
+++ b/src/__snapshots__/generateRoutesModule.test.ts.snap
@@ -2,99 +2,79 @@
 
 exports[`should generate the routes module 1`] = `
 "import React from 'react';
-import { loader as example_src_routes___panel_posts_$slug_LOADER } from '/example/src/routes/__panel/posts/$slug.tsx';
-import { ErrorElement as EXAMPLE_SRC_ROUTES___PANEL_POSTS_$SLUG_ERROR_ELEMENT } from '/example/src/routes/__panel/posts/$slug.tsx';
-import { action as example_src_routes___panel_posts_create_ACTION } from '/example/src/routes/__panel/posts/create.tsx';
-import { loader as example_src_routes___panel_posts_index_LOADER } from '/example/src/routes/__panel/posts/index.tsx';
-import { ErrorBoundary as EXAMPLE_SRC_ROUTES___PANEL_POSTS_INDEX_ERROR_ELEMENT } from '/example/src/routes/__panel/posts/index.tsx';
-import { handle as example_src_routes___panel_users_HANDLE } from '/example/src/routes/__panel/users';
-import { handle as example_src_routes___panel_users_$user_HANDLE } from '/example/src/routes/__panel/users/$user';
-import { handle as example_src_routes___panel_users_$user_index_HANDLE } from '/example/src/routes/__panel/users/$user/index.tsx';
-import { handle as example_src_routes___panel_users_$user_profile_HANDLE } from '/example/src/routes/__panel/users/$user/profile.tsx';
-import { handle as example_src_routes___panel_users_$user_settings_HANDLE } from '/example/src/routes/__panel/users/$user/settings.tsx';
 
 export const routes = [{
   \\"path\\": \\"/\\",
   \\"children\\": [
     {
       \\"path\\": \\"*\\",
-      \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/$.tsx\\")))
+      \\"lazy\\": () => import(\\"/example/src/routes/$.tsx\\")
     },
     {
       \\"children\\": [
         {
           \\"path\\": \\"login\\",
-          \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__auth/login.tsx\\")))
+          \\"lazy\\": () => import(\\"/example/src/routes/__auth/login.tsx\\")
         }
       ]
     },
     {
-      \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel.tsx\\"))),
+      \\"lazy\\": () => import(\\"/example/src/routes/__panel.tsx\\"),
       \\"children\\": [
         {
           \\"path\\": \\"posts\\",
           \\"children\\": [
             {
               \\"path\\": \\":slug\\",
-              \\"loader\\": example_src_routes___panel_posts_$slug_LOADER,
-              \\"errorElement\\": React.createElement(EXAMPLE_SRC_ROUTES___PANEL_POSTS_$SLUG_ERROR_ELEMENT),
-              \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/posts/$slug.tsx\\")))
+              \\"lazy\\": () => import(\\"/example/src/routes/__panel/posts/$slug.tsx\\")
             },
             {
               \\"path\\": \\"create\\",
-              \\"action\\": example_src_routes___panel_posts_create_ACTION,
-              \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/posts/create.tsx\\")))
+              \\"lazy\\": () => import(\\"/example/src/routes/__panel/posts/create.tsx\\")
             },
             {
               \\"index\\": true,
-              \\"loader\\": example_src_routes___panel_posts_index_LOADER,
-              \\"errorElement\\": React.createElement(EXAMPLE_SRC_ROUTES___PANEL_POSTS_INDEX_ERROR_ELEMENT),
-              \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/posts/index.tsx\\")))
+              \\"lazy\\": () => import(\\"/example/src/routes/__panel/posts/index.tsx\\")
             }
           ]
         },
         {
-          \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users.tsx\\"))),
+          \\"lazy\\": () => import(\\"/example/src/routes/__panel/users.tsx\\"),
           \\"path\\": \\"users\\",
           \\"children\\": [
             {
-              \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user.tsx\\"))),
+              \\"lazy\\": () => import(\\"/example/src/routes/__panel/users/$user.tsx\\"),
               \\"path\\": \\":user\\",
               \\"children\\": [
                 {
                   \\"index\\": true,
-                  \\"handle\\": example_src_routes___panel_users_$user_index_HANDLE,
-                  \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user/index.tsx\\")))
+                  \\"lazy\\": () => import(\\"/example/src/routes/__panel/users/$user/index.tsx\\")
                 },
                 {
                   \\"path\\": \\"profile\\",
-                  \\"handle\\": example_src_routes___panel_users_$user_profile_HANDLE,
-                  \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user/profile.tsx\\")))
+                  \\"lazy\\": () => import(\\"/example/src/routes/__panel/users/$user/profile.tsx\\")
                 },
                 {
                   \\"path\\": \\"settings\\",
-                  \\"handle\\": example_src_routes___panel_users_$user_settings_HANDLE,
-                  \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/$user/settings.tsx\\")))
+                  \\"lazy\\": () => import(\\"/example/src/routes/__panel/users/$user/settings.tsx\\")
                 }
-              ],
-              \\"handle\\": example_src_routes___panel_users_$user_HANDLE
+              ]
             },
             {
               \\"index\\": true,
-              \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/__panel/users/index.tsx\\")))
+              \\"lazy\\": () => import(\\"/example/src/routes/__panel/users/index.tsx\\")
             }
-          ],
-          \\"handle\\": example_src_routes___panel_users_HANDLE
+          ]
         }
       ]
     },
     {
       \\"path\\": \\"about\\",
-      \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/about.tsx\\")))
+      \\"lazy\\": () => import(\\"/example/src/routes/about.tsx\\")
     },
     {
       \\"index\\": true,
-      \\"element\\": React.createElement(React.lazy(() => import(\\"/example/src/routes/index.tsx\\")))
+      \\"lazy\\": () => import(\\"/example/src/routes/index.tsx\\")
     }
   ]
 }]

--- a/src/generateRoutesModule.ts
+++ b/src/generateRoutesModule.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import {
   RouteObject,
   LazyRouteFunction,
@@ -50,8 +49,6 @@ function createLayoutRoute(node: RouteNode): RouteObject {
 }
 
 function createPageRoute(node: RouteNode): RouteObject {
-  const code = fs.readFileSync(toAbsolutePath(node.path), 'utf8')
-
   const path =
     node.name === 'index'
       ? { index: true }

--- a/src/generateRoutesModule.ts
+++ b/src/generateRoutesModule.ts
@@ -4,7 +4,7 @@ import {
   NonIndexRouteObject,
 } from 'react-router-dom'
 import type { RouteNode } from './buildRouteTree'
-import { normalizeFilenameToRoute, toAbsolutePath } from './utils'
+import { normalizeFilenameToRoute } from './utils'
 
 let imports: Array<string> = []
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,10 +1,4 @@
 import {
-  createImportName,
-  hasAction,
-  hasErrorBoundary,
-  hasErrorElement,
-  hasHandle,
-  hasLoader,
   isCatchAllRoute,
   isDynamicRoute,
   normalizeFilenameToRoute,
@@ -35,73 +29,4 @@ it('normalizeFilenameToRoute', () => {
   expect(normalizeFilenameToRoute('topic')).toBe('topic')
   expect(normalizeFilenameToRoute('index')).toBe('index')
   expect(normalizeFilenameToRoute('$id')).toBe(':id')
-})
-
-it('createImportName', () => {
-  expect(createImportName('example/src/routes/$.tsx', 'LOADER')).toEqual(
-    'example_src_routes_$_LOADER',
-  )
-  expect(createImportName('example/src/routes/about.tsx', 'ACTION')).toEqual(
-    'example_src_routes_about_ACTION',
-  )
-  expect(
-    createImportName('example/src/routes/__auth/login.tsx', 'LOADER'),
-  ).toEqual('example_src_routes___auth_login_LOADER')
-  expect(
-    createImportName('example/src/routes/__panel/posts/$slug.tsx', 'ACTION'),
-  ).toEqual('example_src_routes___panel_posts_$slug_ACTION')
-})
-
-it('hasLoader', () => {
-  expect(hasLoader(`export const loader = () => {}`)).toEqual(true)
-  expect(hasLoader(`export const loader:LoaderFunction = () => {}`)).toEqual(
-    true,
-  )
-  expect(hasLoader(`const loader = () => {}`)).toEqual(true)
-  expect(hasLoader(`export function loader () {}`)).toEqual(true)
-  expect(hasLoader(`export async function loader() {}`)).toEqual(true)
-  expect(hasLoader(`async function loader () {}`)).toEqual(true)
-  expect(hasLoader(`async function loader () {}`)).toEqual(true)
-})
-
-it('hasAction', () => {
-  expect(hasAction(`export const action = () => {}`)).toEqual(true)
-  expect(hasAction(`export const action:ActionFunction = () => {}`)).toEqual(
-    true,
-  )
-  expect(hasAction(`const action = () => {}`)).toEqual(true)
-  expect(hasAction(`export function action () {}`)).toEqual(true)
-  expect(hasAction(`export async function action() {}`)).toEqual(true)
-  expect(hasAction(`async function action () {}`)).toEqual(true)
-  expect(hasAction(`async function action () {}`)).toEqual(true)
-})
-
-it('hasErrorElement', () => {
-  expect(hasErrorElement(`export const ErrorElement = () => {}`)).toEqual(true)
-  expect(hasErrorElement(`const ErrorElement = () => {}`)).toEqual(true)
-  expect(hasErrorElement(`export function ErrorElement () {}`)).toEqual(true)
-})
-
-it('hasErrorBoundary', () => {
-  expect(hasErrorBoundary(`export const ErrorBoundary = () => {}`)).toEqual(
-    true,
-  )
-  expect(hasErrorBoundary(`const ErrorBoundary = () => {}`)).toEqual(true)
-  expect(hasErrorBoundary(`export function ErrorBoundary () {}`)).toEqual(true)
-})
-
-it('hasHandle', () => {
-  expect(hasHandle(`export const handle = {}`)).toEqual(true)
-  expect(hasHandle(`const handle = {}`)).toEqual(true)
-  expect(hasHandle(`export let handle = {}`)).toEqual(true)
-  expect(hasHandle(`let handle = {}`)).toEqual(true)
-  expect(hasHandle(`export var handle = {}`)).toEqual(true)
-  expect(hasHandle(`var handle = {}`)).toEqual(true)
-
-  expect(hasHandle(`export const handleForm =`)).toEqual(false)
-  expect(hasHandle(`const handleForm =`)).toEqual(false)
-  expect(hasHandle(`export let handleForm =`)).toEqual(false)
-  expect(hasHandle(`let handleForm =`)).toEqual(false)
-  expect(hasHandle(`export var handleForm =`)).toEqual(false)
-  expect(hasHandle(`var handleForm =`)).toEqual(false)
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,14 +2,6 @@ import fs from 'fs'
 import path from 'path'
 import { getOptions } from './options'
 
-const ROUTE_LOADER_REGEX = /(export\s)?(async\s)?(const|function)\sloader/
-const ROUTE_ACTION_REGEX = /(export\s)?(async\s)?(const|function)\saction/
-const ROUTE_ERROR_ELEMENT_REGEX =
-  /(export\s)?(async\s)?(const|function)\sErrorElement/
-const ROUTE_ERROR_BOUNDARY_REGEX =
-  /(export\s)?(async\s)?(const|function)\sErrorBoundary/
-const ROUTE_HANDLE_REGEX = /(export\s)?(const|var|let)\shandle\s/
-
 export function isDirectory(filePath: string) {
   return fs.statSync(filePath).isDirectory()
 }
@@ -42,33 +34,4 @@ export function normalizeFilenameToRoute(filename: string) {
 
 export function toAbsolutePath(filePath: string) {
   return path.join(getOptions().root, filePath)
-}
-
-export function createImportName(filePath: string, postfix: string) {
-  return (
-    filePath
-      .replace(/\//g, '_')
-      .replace(/\.[^/.]+$/, '')
-      .replace(/^_/, '') + `_${postfix}`
-  )
-}
-
-export function hasLoader(code: string) {
-  return ROUTE_LOADER_REGEX.test(code)
-}
-
-export function hasAction(code: string) {
-  return ROUTE_ACTION_REGEX.test(code)
-}
-
-export function hasErrorElement(code: string) {
-  return ROUTE_ERROR_ELEMENT_REGEX.test(code)
-}
-
-export function hasErrorBoundary(code: string) {
-  return ROUTE_ERROR_BOUNDARY_REGEX.test(code)
-}
-
-export function hasHandle(code: string) {
-  return ROUTE_HANDLE_REGEX.test(code)
 }


### PR DESCRIPTION
Closes #48 

React Router has a new feature called Route.lazy. If we use this instead of React.lazy, we don't need to load each handle, loader etc. in individually:

-  https://reactrouter.com/en/main/route/lazy
- https://remix.run/blog/lazy-loading-routes