### PR TITLE
Support absolute path in routesDirectory

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function normalizeFilenameToRoute(filename: string) {
 }
 
 export function toAbsolutePath(filePath: string) {
-  return path.join(getOptions().root, filePath)
+  return path.resolve(getOptions().root, filePath)
 }
 
 export function createImportName(filePath: string, postfix: string) {


### PR DESCRIPTION
I have a Vite app that works with this plugin, with routesDirectory set to the default (src/routes).

When running this addon in storybook (v7 rc.4), Vite's `root` config option gets changed to be the src directory, and this plugin errors when it tries to resolve `src/src/routes`.

In order to solve this, I would like to set routesDirectory to an absolute path:

```ts
RemixRouter({
  routesDirectory: `${__dirname}/src/routes`,
}),
```

...however this does not work at the moment as this path gets added to the end of `root`.

Using path.resolve instead of path.join means that if routesDirectory is an absolute path (starts with `/`) it won't add it to the end of root.