### PR TITLE
Fix documentation error in installation command for PNPM

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -18,7 +18,7 @@ yarn add --dev vite-plugin-remix-router react-router-dom
 ```
 
 ```bash
-pnpm add --dev vite-plugin-remix-router react-router-dom
+pnpm add -D vite-plugin-remix-router react-router-dom
 ```
 
 Then, add the plugin to your `vite.config.ts`:


### PR DESCRIPTION
This commit addresses an error in the documentation for this plugin setup. Specifically, the installation command for PNPM was incorrectly using --dev instead of the correct -D flag. The corrected installation commands are now as follows:

```bash
npm install --save-dev vite-plugin-remix-router react-router-dom
```

```bash
yarn add --dev vite-plugin-remix-router react-router-dom
```

```bash
pnpm add -D vite-plugin-remix-router react-router-dom
```

Installing with "--dev" option, was giving the following error: 
" ERROR  Unknown option: 'dev'
For help, run: pnpm help add"